### PR TITLE
bugfix #1

### DIFF
--- a/R/calc_error_relative_to_nontargets.R
+++ b/R/calc_error_relative_to_nontargets.R
@@ -18,7 +18,8 @@
 calc_error_relative_to_nontargets <- function(data, response, lures) {
   y <- y_nt <- non_target_name <- non_target_value <- NULL
   data <- data %>%
-    tidyr::gather(non_target_name, non_target_value, eval(lures)) %>%
-    dplyr::mutate(y_nt = wrap(y-non_target_value))
+    tidyr::gather(non_target_name, non_target_value, eval(lures))
+
+  data$y_nt <- wrap(data[[response]]-data[["non_target_value"]])
   return(data)
 }


### PR DESCRIPTION
Replaced "y" to "data[["response"]] in function calc_error_relative_to_nontargets. It now runs fine when the response is not y.