### PR TITLE
Change prior on log(kappa) to Normal(2,1). Fixes #15

### DIFF
--- a/R/fit_model.R
+++ b/R/fit_model.R
@@ -191,7 +191,7 @@ fit_model <- function(formula, data, model_type,
       brms::prior_("constant(0)", class = "Intercept", dpar = "mu1") +
       brms::prior_("constant(0)", class = "Intercept", dpar = mu_unif) +
       brms::prior_("constant(-100)", class = "Intercept", dpar = kappa_unif) +
-      brms::prior_("normal(5.0, 0.8)", class = "b", nlpar = "kappa") +
+      brms::prior_("normal(2, 1)", class = "b", nlpar = "kappa") +
       brms::prior_("logistic(0, 1)", class = "b", nlpar = "thetat") +
       brms::prior_("logistic(0, 1)", class = "b", nlpar = "thetant")
 
@@ -268,7 +268,7 @@ fit_model <- function(formula, data, model_type,
       # fix kappa of the second von Mises to (alomst) zero
       brms::prior_("constant(-100)", class = "Intercept", dpar = kappa_unif) +
       # set reasonable priors fpr the to be estimated parameters
-      brms::prior_("normal(2.0, 1)", class = "b", nlpar = "kappa") +
+      brms::prior_("normal(2, 1)", class = "b", nlpar = "kappa") +
       brms::prior_("normal(0, 1)", class = "b", nlpar = "c") +
       brms::prior_("normal(0, 1)", class = "b", nlpar = "a")
 
@@ -355,7 +355,7 @@ fit_model <- function(formula, data, model_type,
       # fix kappa of the second von Mises to (alomst) zero
       brms::prior_("constant(-100)", class = "Intercept", dpar = kappa_unif) +
       # set reasonable priors fpr the to be estimated parameters
-      brms::prior_("normal(2.0, 1)", class = "b", nlpar = "kappa") +
+      brms::prior_("normal(2, 1)", class = "b", nlpar = "kappa") +
       brms::prior_("normal(0, 1)", class = "b", nlpar = "c") +
       brms::prior_("normal(0, 1)", class = "b", nlpar = "s")
 
@@ -442,7 +442,7 @@ fit_model <- function(formula, data, model_type,
       # fix kappa of the second von Mises to (alomst) zero
       brms::prior_("constant(-100)", class = "Intercept", dpar = kappa_unif) +
       # set reasonable priors fpr the to be estimated parameters
-      brms::prior_("normal(2.0, 1)", class = "b", nlpar = "kappa") +
+      brms::prior_("normal(2, 1)", class = "b", nlpar = "kappa") +
       brms::prior_("normal(0, 1)", class = "b", nlpar = "c") +
       brms::prior_("normal(0, 1)", class = "b", nlpar = "a") +
       brms::prior_("normal(0, 1)", class = "b", nlpar = "s")


### PR DESCRIPTION
#### Summary

The default prior generated by brms for parameters named "kappa" on the log scale is Normal(5,0.8), which is inappropriate for kappa - this prior has a mean of 204 on the native scale and assigns a lot of likelihood to values that would overflow the modified bessel function. We had changed it almost everywhere, but it was still present in one model. Closes #15 

#### Tests

#### Release notes

Changed default prior on log(kappa) to Normal(2,1) for the 3 parameter mixture model