### PR TITLE
SDM hotfix for stan filepaths

### DIFF
--- a/R/bmm_model_sdmSimple.R
+++ b/R/bmm_model_sdmSimple.R
@@ -88,12 +88,13 @@ configure_model.sdmSimple <- function(model, data, formula) {
     family <- sdm_simple
 
     # prepare initial stanvars to pass to brms, model formula and priors
-    stan_funs <- readChar('inst/stan_chunks/sdmSimple_funs.stan',
-                          file.info('inst/stan_chunks/sdmSimple_funs.stan')$size)
-    stan_tdata <- readChar('inst/stan_chunks/sdmSimple_tdata.stan',
-                           file.info('inst/stan_chunks/sdmSimple_tdata.stan')$size)
-    stan_likelihood <- readChar('inst/stan_chunks/sdmSimple_likelihood.stan',
-                               file.info('inst/stan_chunks/sdmSimple_likelihood.stan')$size)
+    sc_path <- system.file("stan_chunks", package="bmm")
+    stan_funs <- readChar(paste0(sc_path, '/sdmSimple_funs.stan'),
+                          file.info(paste0(sc_path, '/sdmSimple_funs.stan'))$size)
+    stan_tdata <- readChar(paste0(sc_path, '/sdmSimple_tdata.stan'),
+                           file.info(paste0(sc_path, '/sdmSimple_tdata.stan'))$size)
+    stan_likelihood <- readChar(paste0(sc_path, '/sdmSimple_likelihood.stan'),
+                               file.info(paste0(sc_path, '/sdmSimple_likelihood.stan'))$size)
     stanvars <- brms::stanvar(scode = stan_funs, block = "functions") +
       brms::stanvar(scode = stan_tdata, block = 'tdata') +
       brms::stanvar(scode = stan_likelihood, block = 'likelihood', position="end")

--- a/R/helpers-model.R
+++ b/R/helpers-model.R
@@ -388,8 +388,8 @@ use_model_template <- function(model_name,
                                "     type = '', loop=FALSE,\n",
                                "   )\n   family <- <<model_name>>_family\n\n")
 
-
-    stan_vars_template <- "   # prepare initial stanvars to pass to brms, model formula and priors\n"
+    stan_vars_template <- paste0("   # prepare initial stanvars to pass to brms, model formula and priors\n",
+                                 "   sc_path <- system.file('stan_chunks', package='bmm')\n")
     for (stanvar_block in stanvar_blocks) {
       stan_vars_file <- paste0('inst/stan_chunks/', model_name, '_', stanvar_block, '.stan')
       if(!testing) {
@@ -399,8 +399,8 @@ use_model_template <- function(model_name,
         }
       }
       stan_vars_template <- paste0(stan_vars_template,
-                                   "   stan_", stanvar_block, " <- readChar('inst/stan_chunks/", model_name, "_", stanvar_block, ".stan',\n",
-                                   "      file.info('inst/stan_chunks/", model_name, "_", stanvar_block, ".stan')$size)\n")
+        "   stan_", stanvar_block, " <- readChar(paste0(sc_path, '/", model_name, "_", stanvar_block, ".stan'),\n",
+        "      file.info(paste0(sc_path, '/", model_name, "_", stanvar_block, ".stan'))$size)\n")
     }
     stan_vars_template <- paste0(stan_vars_template, "\n   stanvars <- ")
     i = 1

--- a/man/bmm-package.Rd
+++ b/man/bmm-package.Rd
@@ -12,6 +12,7 @@ Wrapper functions and custom distributions that make it easier to estimate commo
 Useful links:
 \itemize{
   \item \url{https://github.com/venpopov/bmm}
+  \item \url{https://venpopov.github.io/bmm/}
   \item Report bugs at \url{https://github.com/venpopov/bmm/issues}
 }
 


### PR DESCRIPTION
#### Summary

When running the sdmSimple from an installed version of the package, it produced the following error:

```
In file(con, "rb") :
  cannot open file 'inst/stan_chunks/sdmSimple_funs.stan': No such file or directory
```

this hotfix closes #55 by using the logic described here: https://r-pkgs.org/data.html#sec-data-system-file


#### Tests

[X] Confirm that all tests passed
[X] Confirm that devtools::check() produces no errors

#### Release notes
