### PR TITLE
add log_lik and posterior_predict methods for sdmSImple

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bmm
 Title: Easy and Accesible Bayesian Measurement Models using 'brms'
-Version: 0.3.1.9000
+Version: 0.3.2.9000
 Authors@R: c(
     person("Vencislav", "Popov", , "vencislav.popov@gmail.com", role = c("aut", "cre", "cph")),
     person("Gidon", "Frischkorn", , "gidon.frischkorn@psychologie.uzh.ch", role = c("aut", "cph")))

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ### New features
 
 * add a check for the sdmSimple model if the data is sorted by predictors. This leads to much faster sampling. The user can control the default behavior with the `sort_data` argument (#72)
+* add postprocessing methods for sdmSimple to allow for pp_check(), conditional_effects and bridgesampling usage with the model (#30)
 
 # bmm 0.3.0
 

--- a/R/bmm_model_sdmSimple.R
+++ b/R/bmm_model_sdmSimple.R
@@ -106,6 +106,8 @@ configure_model.sdmSimple <- function(model, data, formula) {
       "sdm_simple", dpars = c("mu", "c","kappa"),
       links = c("identity","identity", "log"), lb = c(NA, NA, NA),
       type = "real", loop=FALSE,
+      log_lik = log_lik_sdm_simple,
+      posterior_predict = posterior_predict_sdm_simple
     )
     family <- sdm_simple
 
@@ -146,3 +148,19 @@ postprocess_brm.sdmSimple <- function(model, fit) {
   fit$formula$family$link_c <- "log"
   fit
 }
+
+log_lik_sdm_simple <- function(i, prep) {
+  mu <- brms::get_dpar(prep, "mu", i = i)
+  c <- brms::get_dpar(prep, "c", i = i)
+  kappa <- brms::get_dpar(prep, "kappa", i = i)
+  y <- prep$data$Y[i]
+  dsdm(y, mu, c, kappa, log=T)
+}
+
+posterior_predict_sdm_simple <- function(i, prep, ...) {
+  mu <- brms::get_dpar(prep, "mu", i = i)
+  c <- brms::get_dpar(prep, "c", i = i)
+  kappa <- brms::get_dpar(prep, "kappa", i = i)
+  rsdm(length(mu), mu, c, kappa)
+}
+


### PR DESCRIPTION
#### Summary

Add log_lik and posterior_predict methods for sdm simple
- turns out posterior_epred is not necessary - all the functionality that supposedly depends on it works without it

Now pp_check(), conditional_effects and bayes_factor from bridge sampling work


#### Tests

[x] Confirm that all tests passed
[x] Confirm that devtools::check() produces no errors
