### PR TITLE
Hotfix for default_prior

### DIFF
--- a/R/bmm_model_mixture2p.R
+++ b/R/bmm_model_mixture2p.R
@@ -36,7 +36,7 @@
       ),
       fixed_parameters = list(mu1 = 0, mu2 = 0, kappa2 = -100),
       default_priors = list(
-        kappa = list(main = "normal(2,1)", effects = "normal(0,1)"),
+        kappa = list(main = "normal(2, 1)", effects = "normal(0, 1)"),
         thetat = list(main = "logistic(0, 1)")
       ),
       void_mu = FALSE

--- a/R/helpers-prior.R
+++ b/R/helpers-prior.R
@@ -61,9 +61,10 @@ get_model_prior <- function(object, data, model, formula = object, ...) {
   data <- check_data(model, data, formula)
   formula <- check_formula(model, data, formula)
   config_args <- configure_model(model, data, formula)
+  prior <- configure_prior(model, data, config_args$formula, user_prior = NULL)
 
   dots <- list(...)
-  prior_args <- c(config_args, dots)
+  prior_args <- combine_args(nlist(config_args, dots, prior))
   brms_priors <- brms::do_call(brms::get_prior, prior_args)
 
   combine_prior(brms_priors, prior_args$prior)

--- a/tests/testthat/test-helpers-prior.R
+++ b/tests/testthat/test-helpers-prior.R
@@ -1,64 +1,89 @@
 test_that("get_prior() works with brmsformula", {
-  ff <- brms::bf(count ~ zAge + zBase * Trt + (1|patient))
+  ff <- brms::bf(count ~ zAge + zBase * Trt + (1 | patient))
   prior <- get_prior(ff, data = brms::epilepsy, family = poisson())
   expect_equal(class(prior)[1], "brmsprior")
 })
 
 test_that("get_prior() works with formula", {
-  ff <- count ~ zAge + zBase * Trt + (1|patient)
+  ff <- count ~ zAge + zBase * Trt + (1 | patient)
   prior <- get_prior(ff, data = brms::epilepsy, family = poisson())
   expect_equal(class(prior)[1], "brmsprior")
 })
 
 test_that("get_prior() works with bmmformula if brms >= 2.20.14", {
   # define formula
-  ff <- bmmformula(kappa ~ 1,
-                   thetat ~ 1,
-                   thetant ~ 1)
+  ff <- bmmformula(
+    kappa ~ 1,
+    thetat ~ 1,
+    thetant ~ 1
+  )
 
   # simulate data
   dat <- OberauerLin_2017
 
   # fit the model
   if (utils::packageVersion("brms") >= "2.20.14") {
-    prior <- get_prior(formula = ff,
-                       data = dat,
-                       model = mixture3p(resp_err = "dev_rad",
-                                         nt_features = 'col_nt',
-                                         setsize = "set_size", regex = T))
+    prior <- get_prior(
+      formula = ff,
+      data = dat,
+      model = mixture3p(
+        resp_err = "dev_rad",
+        nt_features = "col_nt",
+        setsize = "set_size", regex = T
+      )
+    )
     expect_equal(class(prior)[1], "brmsprior")
 
-    prior2 <- default_prior(object = ff,
-                            data = dat,
-                            model = mixture3p(resp_err = "dev_rad",
-                                              nt_features = 'col_nt',
-                                              setsize = "set_size", regex = T))
+    prior2 <- default_prior(
+      object = ff,
+      data = dat,
+      model = mixture3p(
+        resp_err = "dev_rad",
+        nt_features = "col_nt",
+        setsize = "set_size", regex = T
+      )
+    )
     expect_equal(prior, prior2)
   }
-
 })
 
 test_that("combine prior returns a brmsprior object", {
-  prior1 <- brms::prior(normal(0,1), class = 'sd', dpar='c')
-  prior2 <- brms::prior(normal(0,1), class = 'sd', dpar='kappa')
+  prior1 <- brms::prior(normal(0, 1), class = "sd", dpar = "c")
+  prior2 <- brms::prior(normal(0, 1), class = "sd", dpar = "kappa")
 
   # combine the prior
-  prior <- combine_prior(prior1,prior2)
+  prior <- combine_prior(prior1, prior2)
   expect_equal(class(prior)[1], "brmsprior")
 })
 
 test_that("in combine prior, prior2 overwrites only shared components with prior1", {
-  prior1 <- brms::prior(normal(0,1), class = 'sd', dpar='c1') +
-    brms::prior(normal(0,1), class = 'sd', dpar='c2') +
-    brms::prior(normal(0,1), class = 'sd', dpar='c3')
-  prior2 <- brms::prior(normal(0,1), class = 'sd', dpar='kappa') +
-    brms::prior(normal(0,2), class = 'sd', dpar='c2')
+  prior1 <- brms::prior(normal(0, 1), class = "sd", dpar = "c1") +
+    brms::prior(normal(0, 1), class = "sd", dpar = "c2") +
+    brms::prior(normal(0, 1), class = "sd", dpar = "c3")
+  prior2 <- brms::prior(normal(0, 1), class = "sd", dpar = "kappa") +
+    brms::prior(normal(0, 2), class = "sd", dpar = "c2")
 
   # combine the prior
-  prior <- combine_prior(prior1,prior2)
+  prior <- combine_prior(prior1, prior2)
   expect_equal(nrow(prior), 4)
-  expect_equal(dplyr::filter(prior, dpar == 'c1'), dplyr::filter(prior1, dpar == 'c1'))
-  expect_equal(dplyr::filter(prior, dpar == 'c2'), dplyr::filter(prior2, dpar == 'c2'))
-  expect_equal(dplyr::filter(prior, dpar == 'c3'), dplyr::filter(prior1, dpar == 'c3'))
-  expect_equal(dplyr::filter(prior, dpar == 'kappa'), dplyr::filter(prior2, dpar == 'kappa'))
+  expect_equal(dplyr::filter(prior, dpar == "c1"), dplyr::filter(prior1, dpar == "c1"))
+  expect_equal(dplyr::filter(prior, dpar == "c2"), dplyr::filter(prior2, dpar == "c2"))
+  expect_equal(dplyr::filter(prior, dpar == "c3"), dplyr::filter(prior1, dpar == "c3"))
+  expect_equal(dplyr::filter(prior, dpar == "kappa"), dplyr::filter(prior2, dpar == "kappa"))
+})
+
+
+test_that("default priors are returned correctly", {
+  if (utils::packageVersion("brms") >= "2.20.14") {
+    dp <- default_prior(bmf(kappa ~ set_size, thetat ~ set_size),
+                        OberauerLin_2017,
+                        mixture2p('dev_rad'))
+  } else {
+    dp <- default_prior(bmf(kappa ~ set_size, thetat ~ set_size),
+                        OberauerLin_2017,
+                        mixture2p('dev_rad'))
+  }
+
+  expect_equal(dp[dp$coef == "set_size2", ]$prior, c("normal(0, 1)", "logistic(0, 1)"))
+  expect_equal(dp[dp$coef == "Intercept", ]$prior, c("normal(2, 1)", "logistic(0, 1)"))
 })

--- a/tests/testthat/test-helpers-prior.R
+++ b/tests/testthat/test-helpers-prior.R
@@ -79,11 +79,11 @@ test_that("default priors are returned correctly", {
                         OberauerLin_2017,
                         mixture2p('dev_rad'))
   } else {
-    dp <- default_prior(bmf(kappa ~ set_size, thetat ~ set_size),
+    dp <- get_model_prior(bmf(kappa ~ set_size, thetat ~ set_size),
                         OberauerLin_2017,
                         mixture2p('dev_rad'))
   }
 
-  expect_equal(dp[dp$coef == "set_size2", ]$prior, c("normal(0, 1)", "logistic(0, 1)"))
+  expect_equal(dp[dp$coef == "" & dp$class == "b", ]$prior, c("","normal(0, 1)"))
   expect_equal(dp[dp$coef == "Intercept", ]$prior, c("normal(2, 1)", "logistic(0, 1)"))
 })


### PR DESCRIPTION
#### Summary

Addresses part of #156 

- fixes the default prior function
- adds a basic test for default prior for one model

I want to add more tests for all model priors, and for stancode to make sure they and other features are coded correctly, but I can do that in a separate PR, so that the bug is quickly patched.

#### Tests

[X] Confirm that all tests passed
[X] Confirm that devtools::check() produces no errors

#### Release notes
