### PR TITLE
disable sort_data check for stancode and default_priors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 ### Bug fixes
 * fix a bug preventing the sort_data check from being executed (#72)
 * fix a bug with the summary() function not displaying implicit parameters (#152)
+* fix a bug in which the sort_data check occured in cases where it shouldn't (#158)
 
 # bmm 0.4.0
 

--- a/R/helpers-model.R
+++ b/R/helpers-model.R
@@ -652,6 +652,8 @@ get_stancode <- function(object, data, model, prior=NULL, formula = object, ...)
 #' @rdname get_stancode
 #' @export
 stancode.bmmformula <- function(object, data, model, prior = NULL, ...) {
+  withr::local_options(bmm.sort_data = FALSE)
+
   # check model, formula and data, and transform data if necessary
   formula <- object
   model <- check_model(model, data, formula)

--- a/R/helpers-prior.R
+++ b/R/helpers-prior.R
@@ -56,6 +56,8 @@ get_model_prior <- function(object, data, model, formula = object, ...) {
     warning2("The 'formula' argument is deprecated for consistency with brms (>= 2.20.14).",
              " Please use 'object' instead.")
   }
+  withr::local_options(bmm.sort_data = FALSE)
+
   formula <- object
   model <- check_model(model, data, formula)
   data <- check_data(model, data, formula)

--- a/tests/testthat/test-helpers-model.R
+++ b/tests/testthat/test-helpers-model.R
@@ -161,6 +161,14 @@ test_that("make_stancode() works with bmmformula if brms >= 2.20.14", {
   expect_equal(class(sd)[1], "character")
 })
 
+test_that("no check for with make_stancode function", {
+  withr::local_options('bmm.sort_data' = 'check')
+  expect_no_message(make_stancode(bmf(kappa ~ set_size, c ~ set_size),
+                                  OberauerLin_2017,
+                                  sdmSimple('dev_rad')))
+})
+
+
 
 test_that("change_constants() works", {
   model <- sdmSimple(resp_err = "y")

--- a/tests/testthat/test-helpers-prior.R
+++ b/tests/testthat/test-helpers-prior.R
@@ -87,3 +87,11 @@ test_that("default priors are returned correctly", {
   expect_equal(dp[dp$coef == "" & dp$class == "b", ]$prior, c("","normal(0, 1)"))
   expect_equal(dp[dp$coef == "Intercept", ]$prior, c("normal(2, 1)", "logistic(0, 1)"))
 })
+
+test_that("no check for sort_data with default_priors function", {
+  withr::local_options('bmm.sort_data' = 'check')
+  res <- capture_messages(get_model_prior(bmf(kappa ~ set_size, c ~ set_size),
+                                       OberauerLin_2017,
+                                       sdmSimple('dev_rad')))
+  expect_false(any(grepl("sort", res)))
+})


### PR DESCRIPTION
fixes #158 

#### Tests

[x] Confirm that all tests passed
[x] Confirm that devtools::check() produces no errors

#### Release notes
