### PR TITLE
Remove links argument #214

### DIFF
--- a/R/model_imm.R
+++ b/R/model_imm.R
@@ -5,7 +5,7 @@
 
 .model_imm <-
   function(resp_error = NULL, nt_features = NULL, nt_distances = NULL,
-           set_size = NULL, regex = FALSE, links = NULL, version = "full",
+           set_size = NULL, regex = FALSE, version = "full", links = NULL,
            call = NULL, ...) {
     out <- structure(
       list(
@@ -116,8 +116,6 @@
 #' @param regex Logical. If TRUE, the `nt_features` and `nt_distances` arguments
 #'   are interpreted as a regular expression to match the non-target feature
 #'   columns in the dataset.
-#' @param links A list of links for the parameters. *Currently does not affect
-#'   the model fits, but it will in the future.*
 #' @param version Character. The version of the IMM model to use. Can be one of
 #'  `full`, `bsc`, or `abc`. The default is `full`.
 #' @param ... used internally for testing, ignore it
@@ -178,8 +176,7 @@
 #'            backend = 'cmdstanr')
 #'}
 #' @export
-imm <- function(resp_error, nt_features, nt_distances, set_size, regex = FALSE,
-                links = NULL, version = "full", ...) {
+imm <- function(resp_error, nt_features, nt_distances, set_size, regex = FALSE, version = "full", ...) {
   call <- match.call()
   dots <- list(...)
   if ("setsize" %in% names(dots)) {
@@ -192,7 +189,7 @@ imm <- function(resp_error, nt_features, nt_distances, set_size, regex = FALSE,
   stop_missing_args()
   .model_imm(resp_error = resp_error, nt_features = nt_features,
              nt_distances = nt_distances, set_size = set_size, regex = regex,
-             links = links, version = version, call = call, ...)
+             version = version, call = call, ...)
 }
 
 
@@ -201,8 +198,7 @@ imm <- function(resp_error, nt_features, nt_distances, set_size, regex = FALSE,
 #' @rdname imm
 #' @keywords bmmodel
 #' @export
-IMMfull <- function(resp_error, nt_features, nt_distances, set_size, regex = FALSE,
-                    links = NULL, ...) {
+IMMfull <- function(resp_error, nt_features, nt_distances, set_size, regex = FALSE, ...) {
   call <- match.call()
   dots <- list(...)
   warning("The function `IMMfull()` is deprecated. Please use `imm(version = 'full')` instead.")
@@ -213,15 +209,14 @@ IMMfull <- function(resp_error, nt_features, nt_distances, set_size, regex = FAL
   stop_missing_args()
   .model_imm(resp_error = resp_error, nt_features = nt_features,
              nt_distances = nt_distances, set_size = set_size, regex = regex,
-             links = links, version = "full", call = call, ...)
+             version = "full", call = call, ...)
 }
 
 
 #' @rdname imm
 #' @keywords bmmodel
 #' @export
-IMMbsc <- function(resp_error, nt_features, nt_distances, set_size, regex = FALSE,
-                   links = NULL, ...) {
+IMMbsc <- function(resp_error, nt_features, nt_distances, set_size, regex = FALSE, ...) {
   call <- match.call()
   dots <- list(...)
   warning("The function `IMMbsc()` is deprecated. Please use `imm(version = 'bsc')` instead.")
@@ -232,14 +227,13 @@ IMMbsc <- function(resp_error, nt_features, nt_distances, set_size, regex = FALS
   stop_missing_args()
   .model_imm(resp_error = resp_error, nt_features = nt_features,
              nt_distances = nt_distances, set_size = set_size, regex = regex,
-             links = links, version = "bsc", call = call, ...)
+             version = "bsc", call = call, ...)
 }
 
 #' @rdname imm
 #' @keywords bmmodel
 #' @export
-IMMabc <- function(resp_error, nt_features, set_size, regex = FALSE, links = NULL,
-                   ...) {
+IMMabc <- function(resp_error, nt_features, set_size, regex = FALSE, ...) {
   call <- match.call()
   dots <- list(...)
   warning("The function `IMMabc()` is deprecated. Please use `imm(version = 'abc')` instead.")
@@ -248,9 +242,10 @@ IMMabc <- function(resp_error, nt_features, set_size, regex = FALSE, links = NUL
     warning("The argument 'setsize' is deprecated. Please use 'set_size' instead.")
   }
   stop_missing_args()
-  .model_imm(resp_error = resp_error, nt_features = nt_features,
-             set_size = set_size, regex = regex, links = links,
-             version = "abc", call = call, ...)
+  .model_imm(
+    resp_error = resp_error, nt_features = nt_features, set_size = set_size,
+    regex = regex, version = "abc", call = call, ...
+  )
 }
 
 #############################################################################!

--- a/R/model_mixture2p.R
+++ b/R/model_mixture2p.R
@@ -55,8 +55,6 @@
 #'   the response error. The response Error should code the response relative to
 #'   the to-be-recalled target in radians. You can transform the response error
 #'   in degrees to radian using the `deg2rad` function.
-#' @param links A list of links for the parameters. *Currently does not affect
-#'   the model fits, but it will in the future.*
 #' @param ... used internally for testing, ignore it
 #' @return An object of class `bmmodel`
 #' @keywords bmmodel
@@ -79,10 +77,10 @@
 #'            backend = 'cmdstanr')
 #' }
 #' @export
-mixture2p <- function(resp_error, links = NULL, ...) {
+mixture2p <- function(resp_error, ...) {
   call <- match.call()
   stop_missing_args()
-  .model_mixture2p(resp_error = resp_error, links = links, call = call, ...)
+  .model_mixture2p(resp_error = resp_error, call = call, ...)
 }
 
 #############################################################################!

--- a/R/model_mixture3p.R
+++ b/R/model_mixture3p.R
@@ -7,7 +7,7 @@
 
   out <- structure(
     list(
-      resp_vars = nlist(resp_error),
+      resp_vars = nlist(resp_error), 
       other_vars = nlist(nt_features, set_size),
       domain = "Visual working memory",
       task = "Continuous reproduction",
@@ -76,8 +76,6 @@
 #'   fixed.
 #' @param regex Logical. If TRUE, the `nt_features` argument is interpreted as
 #'  a regular expression to match the non-target feature columns in the dataset.
-#' @param links A list of links for the parameters. *Currently does not affect
-#'   the model fits, but it will in the future.*
 #' @param ... used internally for testing, ignore it
 #' @return An object of class `bmmodel`
 #' @keywords bmmodel
@@ -122,8 +120,7 @@
 #'            iter = 500,
 #'            backend = 'cmdstanr')
 #' }
-mixture3p <- function(resp_error, nt_features, set_size, regex = FALSE,
-                      links = NULL, ...) {
+mixture3p <- function(resp_error, nt_features, set_size, regex = FALSE, ...) {
   call <- match.call()
   dots <- list(...)
   if ("setsize" %in% names(dots)) {
@@ -132,8 +129,7 @@ mixture3p <- function(resp_error, nt_features, set_size, regex = FALSE,
   }
   stop_missing_args()
   .model_mixture3p(resp_error = resp_error, nt_features = nt_features,
-                   set_size = set_size, regex = regex, links = links,
-                   call = call, ...)
+                   set_size = set_size, regex = regex, call = call, ...)
 }
 
 #############################################################################!

--- a/R/model_sdm.R
+++ b/R/model_sdm.R
@@ -57,8 +57,6 @@
 #'   response error. The response error should code the response relative to the
 #'   to-be-recalled target in radians. You can transform the response error in
 #'   degrees to radians using the `deg2rad` function.
-#' @param links A list of links for the parameters. *Currently does not affect
-#'   the model fits, but it will in the future.*
 #' @param version Character. The version of the model to use. Currently only
 #'   "simple" is supported.
 #' @param ... used internally for testing, ignore it
@@ -95,19 +93,19 @@
 #' lines(x, dsdm(x, mu=0, c=coef['c_Intercept'],
 #'               kappa=coef['kappa_Intercept']), col='red')
 #' }
-sdm <- function(resp_error, links = NULL, version = "simple", ...) {
+sdm <- function(resp_error, version = "simple", ...) {
   call <- match.call()
   stop_missing_args()
-  .model_sdm(resp_error = resp_error, links = links, version = version, call = call, ...)
+  .model_sdm(resp_error = resp_error, version = version, call = call, ...)
 }
 
 #' @rdname SDM
 #' @export
-sdmSimple <- function(resp_error, links = NULL, version = "simple", ...) {
+sdmSimple <- function(resp_error, version = "simple", ...) {
   warning("The function `sdmSimple()` is deprecated. Please use `sdm()` instead.")
   call <- match.call()
   stop_missing_args()
-  .model_sdm(resp_error = resp_error, links = links, version = version, call = call, ...)
+  .model_sdm(resp_error = resp_error, version = version, call = call, ...)
 }
 
 #############################################################################!

--- a/man/SDM.Rd
+++ b/man/SDM.Rd
@@ -6,18 +6,15 @@
 \alias{sdmSimple}
 \title{Signal Discrimination Model (SDM) by Oberauer (2023)}
 \usage{
-sdm(resp_error, links = NULL, version = "simple", ...)
+sdm(resp_error, version = "simple", ...)
 
-sdmSimple(resp_error, links = NULL, version = "simple", ...)
+sdmSimple(resp_error, version = "simple", ...)
 }
 \arguments{
 \item{resp_error}{The name of the variable in the dataset containing the
 response error. The response error should code the response relative to the
 to-be-recalled target in radians. You can transform the response error in
 degrees to radians using the \code{deg2rad} function.}
-
-\item{links}{A list of links for the parameters. \emph{Currently does not affect
-the model fits, but it will in the future.}}
 
 \item{version}{Character. The version of the model to use. Currently only
 "simple" is supported.}

--- a/man/bmm.Rd
+++ b/man/bmm.Rd
@@ -98,10 +98,10 @@ backend interface to Stan.
 \section{Supported Models}{
 The following models are supported:
 \itemize{
-\item imm(resp_error, nt_features, nt_distances, set_size, regex, links, version)
-\item mixture2p(resp_error, links)
-\item mixture3p(resp_error, nt_features, set_size, regex, links)
-\item sdm(resp_error, links, version)
+\item imm(resp_error, nt_features, nt_distances, set_size, regex, version)
+\item mixture2p(resp_error)
+\item mixture3p(resp_error, nt_features, set_size, regex)
+\item sdm(resp_error, version)
 }
 
 Type  ?modelname  to get information about a specific model, e.g.  ?imm

--- a/man/imm.Rd
+++ b/man/imm.Rd
@@ -13,32 +13,15 @@ imm(
   nt_distances,
   set_size,
   regex = FALSE,
-  links = NULL,
   version = "full",
   ...
 )
 
-IMMfull(
-  resp_error,
-  nt_features,
-  nt_distances,
-  set_size,
-  regex = FALSE,
-  links = NULL,
-  ...
-)
+IMMfull(resp_error, nt_features, nt_distances, set_size, regex = FALSE, ...)
 
-IMMbsc(
-  resp_error,
-  nt_features,
-  nt_distances,
-  set_size,
-  regex = FALSE,
-  links = NULL,
-  ...
-)
+IMMbsc(resp_error, nt_features, nt_distances, set_size, regex = FALSE, ...)
 
-IMMabc(resp_error, nt_features, set_size, regex = FALSE, links = NULL, ...)
+IMMabc(resp_error, nt_features, set_size, regex = FALSE, ...)
 }
 \arguments{
 \item{resp_error}{The name of the variable in the provided dataset containing
@@ -64,9 +47,6 @@ fixed.}
 \item{regex}{Logical. If TRUE, the \code{nt_features} and \code{nt_distances} arguments
 are interpreted as a regular expression to match the non-target feature
 columns in the dataset.}
-
-\item{links}{A list of links for the parameters. \emph{Currently does not affect
-the model fits, but it will in the future.}}
 
 \item{version}{Character. The version of the IMM model to use. Can be one of
 \code{full}, \code{bsc}, or \code{abc}. The default is \code{full}.}

--- a/man/mixture2p.Rd
+++ b/man/mixture2p.Rd
@@ -4,16 +4,13 @@
 \alias{mixture2p}
 \title{Two-parameter mixture model by Zhang and Luck (2008).}
 \usage{
-mixture2p(resp_error, links = NULL, ...)
+mixture2p(resp_error, ...)
 }
 \arguments{
 \item{resp_error}{The name of the variable in the provided dataset containing
 the response error. The response Error should code the response relative to
 the to-be-recalled target in radians. You can transform the response error
 in degrees to radian using the \code{deg2rad} function.}
-
-\item{links}{A list of links for the parameters. \emph{Currently does not affect
-the model fits, but it will in the future.}}
 
 \item{...}{used internally for testing, ignore it}
 }

--- a/man/mixture3p.Rd
+++ b/man/mixture3p.Rd
@@ -4,7 +4,7 @@
 \alias{mixture3p}
 \title{Three-parameter mixture model by Bays et al (2009).}
 \usage{
-mixture3p(resp_error, nt_features, set_size, regex = FALSE, links = NULL, ...)
+mixture3p(resp_error, nt_features, set_size, regex = FALSE, ...)
 }
 \arguments{
 \item{resp_error}{The name of the variable in the dataset containing
@@ -24,9 +24,6 @@ fixed.}
 
 \item{regex}{Logical. If TRUE, the \code{nt_features} argument is interpreted as
 a regular expression to match the non-target feature columns in the dataset.}
-
-\item{links}{A list of links for the parameters. \emph{Currently does not affect
-the model fits, but it will in the future.}}
 
 \item{...}{used internally for testing, ignore it}
 }


### PR DESCRIPTION
#### Summary

Removes the `link` argument to the models. It was not yet doing anything and better to avoid it for the cran submission and add it later when the functionality is there.

#### Tests

[x] Confirm that all tests passed
[x] Confirm that devtools::check() produces no errors

#### Release notes
