### PR TITLE
Add CRAN badges to readme

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -12,9 +12,11 @@ knitr::opts_chunk$set(
 set.seed(1152)
 ```
 # bmm   <!-- badges: start -->
+[![CRAN status](https://www.r-pkg.org/badges/version/bmm)](https://CRAN.R-project.org/package=bmm)
 [![bmm status badge](https://popov-lab.r-universe.dev/badges/bmm)](https://popov-lab.r-universe.dev/bmm)
 [![R-CMD-check](https://github.com/venpopov/bmm/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/venpopov/bmm/actions/workflows/R-CMD-check.yaml)
 [![test-coverage](https://github.com/venpopov/bmm/actions/workflows/test-coverage.yaml/badge.svg)](https://github.com/venpopov/bmm/actions/workflows/test-coverage.yaml)
+[![downloads](https://cranlogs.r-pkg.org/badges/bmm)](https://cran.r-project.org/package=bmm)
 <!-- badges: end -->
 
 ## Overview

--- a/README.md
+++ b/README.md
@@ -3,10 +3,13 @@
 
 # bmm <!-- badges: start -->
 
+[![CRAN
+status](https://www.r-pkg.org/badges/version/bmm)](https://CRAN.R-project.org/package=bmm)
 [![bmm status
 badge](https://popov-lab.r-universe.dev/badges/bmm)](https://popov-lab.r-universe.dev/bmm)
 [![R-CMD-check](https://github.com/venpopov/bmm/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/venpopov/bmm/actions/workflows/R-CMD-check.yaml)
 [![test-coverage](https://github.com/venpopov/bmm/actions/workflows/test-coverage.yaml/badge.svg)](https://github.com/venpopov/bmm/actions/workflows/test-coverage.yaml)
+[![downloads](https://cranlogs.r-pkg.org/badges/bmm)](https://cran.r-project.org/package=bmm)
 <!-- badges: end -->
 
 ## Overview


### PR DESCRIPTION
#### Summary
- add CRAN badge with version number to ReadMe
- add download statistics badge to ReadMe (can be uncommented for now)

If you had other badges in mind, feel free to adapt the pull request. I also re-ordered the badges to first display the current versions on CRAN and R-Universe, and then give the information about test-checks.

#### Tests

[x] Confirm that all tests passed
[x] Confirm that devtools::check() produces no errors

#### Release notes
