### PR TITLE
align `file_refit` options with brms

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 ### New features
 * Updates to the `bmf2bf` S3 methods to more flexibly accommodate the translation of `bmmformulas` into `brmsformulas`
+* the `file_refit` argument of the `bmm` function now accepts character string like brms. A warning is given when "on_change" is specified, as this is not currently implemented for `bmmodels`.
 
 ### Bug fixes
 * Fix a conflict in setting default priors when model parameters were transformed in a non-linear formula

--- a/R/bmm.R
+++ b/R/bmm.R
@@ -45,11 +45,11 @@
 #' @param file_compress Logical or a character string, specifying one of the
 #'   compression algorithms supported by [saveRDS] when saving
 #'   the fitted model object.
-#' @param file_refit Logical. Modifies when the fit stored via the `file` argument is
+#' @param file_refit Logical or character string. Modifies when the fit stored via the `file` argument is
 #'   re-used. Can be set globally for the current \R session via the
-#'   `"bmm.file_refit"` option (see [options]). If `TRUE` (the default), the
-#'   model is re-used if the file exists. If `FALSE`, the model is re-fitted. Note
-#'   that unlike `brms`, there is no "on_change" option
+#'   `"bmm.file_refit"` option (see [options]). If `TRUE` or "always", the
+#'   model is fitted again. If `FALSE` or "never" (the default), the model saved under the name specified in `file`
+#'   will be re-used. Note that unlike in `brms`, there is no "on_change" option
 #' @param ... Further arguments passed to [brms::brm()] or Stan. See the
 #'   description of [brms::brm()] for more details
 #'

--- a/R/utils.R
+++ b/R/utils.R
@@ -683,6 +683,19 @@ deprecated_args <- function(...) {
 
 read_bmmfit <- function(file, file_refit) {
   file <- check_rds_file(file)
+
+  if(is.character(file_refit)) {
+    stopif(!tolower(file_refit) %in% c("never", "always", "on_change"),
+           glue("You have provided an invalid option for the file_refit argument.\n",
+                "Valid options are: \"never\" or \"always\" \n",
+                "The \"on_change\" option available in brms is currently not implemented for bmm."))
+
+    warnif(tolower(file_refit) == "on_change",
+           glue("The \"on_change\" option for the file_refit argument available in brms,\n",
+                "is currently not implemented for bmm.\n",
+                "To avoid overwriting an already saved bmmfit object, file_refit was set to \"never\"."))
+    file_refit <- ifelse(file_refit == "always", TRUE, FALSE)
+  }
   if (is.null(file) || file_refit) {
     return(NULL)
   }

--- a/man/bmm.Rd
+++ b/man/bmm.Rd
@@ -77,11 +77,11 @@ later usage. If the directory of the file does not exist, it will be created.}
 compression algorithms supported by \link{saveRDS} when saving
 the fitted model object.}
 
-\item{file_refit}{Logical. Modifies when the fit stored via the \code{file} argument is
+\item{file_refit}{Logical or character string. Modifies when the fit stored via the \code{file} argument is
 re-used. Can be set globally for the current \R session via the
-\code{"bmm.file_refit"} option (see \link{options}). If \code{TRUE} (the default), the
-model is re-used if the file exists. If \code{FALSE}, the model is re-fitted. Note
-that unlike \code{brms}, there is no "on_change" option}
+\code{"bmm.file_refit"} option (see \link{options}). If \code{TRUE} or "always", the
+model is fitted again. If \code{FALSE} or "never" (the default), the model saved under the name specified in \code{file}
+will be re-used. Note that unlike in \code{brms}, there is no "on_change" option}
 
 \item{...}{Further arguments passed to \code{\link[brms:brm]{brms::brm()}} or Stan. See the
 description of \code{\link[brms:brm]{brms::brm()}} for more details}


### PR DESCRIPTION
#### Summary
- Allow "never" and "always" to be passed to `file_refit`. Throw a warning if "on_change" is passed

#### Tests

[x] Confirm that all tests passed
[x] Confirm that devtools::check() produces no errors

#### Release notes
* the `file_refit` argument of the `bmm` function now accepts character string like brms. A warning is given when "on_change" is specified, as this is not currently implemented for `bmmodels`.