### PR TITLE
Documentation crt bars gabors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,9 @@
 ### Bug fixes
 * Fix a conflict in setting default priors when model parameters were transformed in a non-linear formula
 
+### Documentation
+* add documentation to the article of the [continuous reproduction task](https://venpopov.github.io/bmm/articles/bmm_vwm_crt.html) for how to pre-process half-circular stimulus spaces when using `bmmodels` of the `circular` model class
+
 # bmm 1.0.0
 
 First version of the package on published on CRAN!

--- a/vignettes/articles/bmm_vwm_crt.Rmd
+++ b/vignettes/articles/bmm_vwm_crt.Rmd
@@ -67,7 +67,7 @@ The `bmm` package implements several measurement models for analyzing continuous
 
 # Preparing data from half-circular stimulus spaces
 
-As already mentioned, some task require subjects to remember orientations (e.g. of bars or Gabor patches) without a direction. With such stimulus material the response error can range only from -90 to 90 degrees (or -pi/2 to pi/2), unlike for a full circular color, shape, or orientation space with directions (arrows or triangles). In case of orientations without a direction, you thus have to multiply the `response_error` by 2 when pre-processing the data, so that the response error ranges from -180 to 180 degrees (or -pi to pi). The same applies to the `nt_features` relative to the target orientation.
+As already mentioned, some task require subjects to remember orientations (e.g. of bars or Gabor patches) without a direction. With such stimulus material the response error can range only from -90 to 90 degrees (or -pi/2 to pi/2). When using data from such a task, you have to multiply the `response_error` by 2 when pre-processing the data, so that the response error ranges from -180 to 180 degrees (or -pi to pi). The same applies to the `nt_features` relative to the target orientation.
 
 
 # References

--- a/vignettes/articles/bmm_vwm_crt.Rmd
+++ b/vignettes/articles/bmm_vwm_crt.Rmd
@@ -64,7 +64,11 @@ The `bmm` package implements several measurement models for analyzing continuous
 #### The Signal Discrimination Model (SDM) by [@Oberauer_2023]  {.unnumbered}
 
   - see `?sdm` and [the SDM article](https://venpopov.github.io/bmm/articles/bmm_sdm_simple.html)
-    
-    
+
+# Preparing data from half-circular stimulus spaces
+
+As already mentioned, some task require subjects to remember orientations (e.g. of bars or Gabor patches) without a direction. With such stimulus material the response error can range only from -90 to 90 degrees (or -pi/2 to pi/2), unlike for a full circular color, shape, or orientation space with directions (arrows or triangles). In case of orientations without a direction, you thus have to multiply the `response_error` by 2 when pre-processing the data, so that the response error ranges from -180 to 180 degrees (or -pi to pi). The same applies to the `nt_features` relative to the target orientation.
+
+
 # References
 


### PR DESCRIPTION
#### Summary
- add documentation to the article of the continuous reproduction task for how to pre-process half-circular stimulus spaces when using `bmmodels` of the `circular` model class
 
#### Tests

[x] Confirm that all tests passed
[x] Confirm that devtools::check() produces no errors

#### Release notes
- add documentation to the article of the continuous reproduction task for how to pre-process half-circular stimulus spaces when using `bmmodels` of the `circular` model class