### PR TITLE
Add check for variables in data in `check_model.m3_custom`

### DIFF
--- a/R/bmmformula.R
+++ b/R/bmmformula.R
@@ -458,7 +458,7 @@ apply_links <- function(formula, links) {
   if (length(links) == 0) {
     return(formula)
   }
-  
+
   pars_with_links <- names(links)
   replacements <- sapply(pars_with_links, function(par) {
     switch(links[[par]],
@@ -469,12 +469,12 @@ apply_links <- function(formula, links) {
       stop2("Unknown link type {links[[par]]}. Check ?apply_links for supported types")
     )
   })
-  
+
   tbr_patterns <- paste0("\\b", pars_with_links, "\\b") # match whole word only
   names(tbr_patterns) <- pars_with_links
 
   for (dpar in names(formula)[is_nl(formula)]) {
-    formula_str <- deparse(formula[[dpar]])
+    formula_str <- deparse(formula[[dpar]], width.cutoff = 500L)
     for (par in pars_with_links) {
       formula_str <- gsub(tbr_patterns[par], replacements[par], formula_str)
     }

--- a/R/model_m3.R
+++ b/R/model_m3.R
@@ -121,7 +121,7 @@
 #'  `ss`, `cs`, or `custom`. The default is `custom`.
 #' @param ... used internally for testing, ignore it
 #' @return An object of class `bmmodel`
-#' 
+#'
 #' @details `r model_info(.model_m3(), components =c('domain', 'task', 'name', 'citation'))`
 #' #### Version: `ss`
 #' `r model_info(.model_m3(version = "ss"), components = c('requirements', 'parameters', 'fixed_parameters', 'links', 'prior'))`
@@ -142,7 +142,7 @@ m3 <- function(resp_cats, num_options, choice_rule = "softmax", version = "custo
   call <- match.call()
   stop_missing_args()
   stopif(
-    !version %in% c("custom", "cs", "ss"), 
+    !version %in% c("custom", "cs", "ss"),
     'Unknown version: {version}. It should be one of "ss", "cs" or "custom"'
   )
   stopif(
@@ -150,7 +150,7 @@ m3 <- function(resp_cats, num_options, choice_rule = "softmax", version = "custo
     'Unsupported choice rule "{choice_rule}. Must be one of "simple" or "softmax"'
   )
   stopif(
-    length(num_options) != length(resp_cats), 
+    length(num_options) != length(resp_cats),
     "The option variables should have the same length as the response variables."
   )
   names(num_options) <- names(num_options) %||% paste0("n_opt_",resp_cats)
@@ -171,6 +171,7 @@ check_model.m3_custom <- function(model, data = NULL, formula = NULL) {
     user_pars <- rhs_vars(formula[is_nl(formula)])
     user_pars <- setdiff(user_pars, names(formula[is_nl(formula)]))
     user_pars <- setdiff(user_pars, names(model$parameters))
+    user_pars <- setdiff(user_pars, colnames(data))
     model$parameters <- c(model$parameters, setNames(user_pars, user_pars))
   }
 
@@ -197,7 +198,7 @@ check_model.m3_custom <- function(model, data = NULL, formula = NULL) {
     )
   })
   model$default_priors <- c(model$default_priors, additional_priors)
-  
+
   NextMethod("check_model")
 }
 
@@ -321,7 +322,7 @@ bmf2bf.m3 <- function(model, formula) {
   # set the base brmsformula based
   cat <- resp_cats[1]
   brms_formula <- brms::bf(glue(
-    "Y | trials(nTrials) ~ 
+    "Y | trials(nTrials) ~
     {open}
     {n_opt_idx_vars[cat]} * ({cat} {operator} {open_n_opts}{options_vars[cat]}{close_n_opts}) + (1 - {n_opt_idx_vars[cat]}) * {zero_opt}
     {close}"
@@ -331,7 +332,7 @@ bmf2bf.m3 <- function(model, formula) {
   # another parameter and add the corresponding brms function
   for (cat in resp_cats[-1]) {
     brms_formula <- brms_formula + glue_nlf(
-      "mu{cat} ~ 
+      "mu{cat} ~
       {open}
       {n_opt_idx_vars[cat]} * ({cat} {operator} {open_n_opts}{options_vars[cat]}{close_n_opts}) + (1 - {n_opt_idx_vars[cat]}) * {zero_opt}
       {close}"
@@ -400,7 +401,7 @@ construct_m3_act_funs <- function(model = NULL, warnings = TRUE) {
   }
 
   stopif(
-    !inherits(model, "m3") || !model$version %in% c("ss", "cs"), 
+    !inherits(model, "m3") || !model$version %in% c("ss", "cs"),
     'Activation functions can only be generated for "m3" models "ss" and "cs"'
   )
 
@@ -437,7 +438,7 @@ construct_m3_act_funs <- function(model = NULL, warnings = TRUE) {
       formula(glue("{resp_cats[4]} ~ b + f * a")),
       formula(glue("{resp_cats[5]} ~ b"))
     )
-  } 
+  }
 
   reset_env(act_funs)
 }

--- a/bmm.Rproj
+++ b/bmm.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 036cbb61-7876-450a-8128-5ba8fc0a10a1
 
 RestoreWorkspace: No
 SaveWorkspace: No

--- a/tests/testthat/test-model_m3.R
+++ b/tests/testthat/test-model_m3.R
@@ -20,9 +20,9 @@ test_that("construct_m3_act_funs works with complex span m3", {
   expect_equal(
     construct_m3_act_funs(model, warnings = FALSE),
     bmf(
-      correct ~ b + a + c, 
-      dist_context ~ b + f * a + f * c, 
-      other ~ b + a, 
+      correct ~ b + a + c,
+      dist_context ~ b + f * a + f * c,
+      other ~ b + a,
       dist_other ~ b + f * a,
       npl ~ b
     ),
@@ -233,6 +233,53 @@ test_that("m3 works with num_options as a numeric vector", {
   expect_silent(bmm(
     formula = formula,
     data = oberauer_lewandowsky_2019_e1,
+    model = my_model,
+    backend = 'mock',
+    mock_fit = 1,
+    rename = F
+  ))
+})
+
+test_that("m3_custom version works with variables contained in data in the activation formulas",{
+  my_data <- data.frame(
+    corr = c(5,6,7,8),
+    other = c(1,2,3,4),
+    npl = c(1,2,3,4),
+    time = c(1,2,1,2),
+    id = c(1,1,2,2)
+  )
+
+  formula <- bmf(
+    corr ~ b + a + cstart + cslope * time,
+    other ~ b + a,
+    npl ~ b,
+    a ~ 1 ,
+    cstart ~ 1,
+    cslope ~ 1
+  )
+
+  my_model <- m3(
+    resp_cats = c("corr", "other", "npl"),
+    num_options = c(1, 2, 3),
+    choice_rule = "softmax",
+    version = "custom"
+  )
+
+  my_model$links <- list(
+    a = "log",
+    cstart = "log",
+    cslope = "log"
+  )
+
+  my_model$default_priors <- list(
+    a = list(main = "normal(0, 0.5)", effects = "normal(0, 0.5)"),
+    cstart = list(main = "normal(0, 0.5)", effects = "normal(0, 0.5)"),
+    cslope = list(main = "normal(0, 0.5)", effects = "normal(0, 0.5)")
+  )
+
+  expect_silent(bmm(
+    formula = formula,
+    data = my_data,
     model = my_model,
     backend = 'mock',
     mock_fit = 1,


### PR DESCRIPTION
#### Summary
- Resolve issue with including variables contained in the data in non-linear formula for the `m3_custom` version of the `m3`
- The `check_model.m3_custom` method now also tests if any variables used in non-linear formulas are contained in the data and will not include those into the model parameters

#### Tests

[x] Confirm that all tests passed
[x] Confirm that devtools::check() produces no errors

#### Release notes
- I think we do not need to add something to the release notes for this fix as the `m3` is not yet included in the package.