### PR TITLE
Issue/264 bug null formula

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bmm
 Title: Easy and Accessible Bayesian Measurement Models Using 'brms'
-Version: 1.1.0.9000
+Version: 1.1.1.9000
 Authors@R: c(
     person("Vencislav", "Popov", , "vencislav.popov@gmail.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0002-8073-4199")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,9 @@
 # bmm (development version)
 
-# bmm 1.1.0
+# bmm 1.1.1
 
 ### New models
-* Add the Memory Measurement Model (Oberauer & Lewandowsky, 2019) as new model class **m3** with three versions: simple span (**ss**), complex span (**cs**), and **custom**. For details, see the [article](https://venpopov.github.io/bmm/articles/bmm_m3.html) on the `bmm` website (#237). Thanks to @GidonFrischkorn and @chenyu-psy
+* Add the Memory Measurement Model (Oberauer & Lewandowsky, 2019) and its generalization as the Multinomial Measurement Model for categorical decision tasks as new model class **m3** with three versions: simple span (**ss**), complex span (**cs**), and **custom**. For details, see the [article](https://venpopov.github.io/bmm/articles/bmm_m3.html) on the `bmm` website (#237). Thanks to @GidonFrischkorn and @chenyu-psy
 
 ### New features
 * Updates to the `bmf2bf` S3 methods for more flexible translation of `bmmformulas` into `brmsformulas` (#227).
@@ -14,6 +14,8 @@
 
 ### Bug fixes
 * Fix conflict in setting default priors when model parameters were transformed in a non-linear formula (#232).
+* Allow a NULL formula (`formula(NULL)`) to be added to a bmmformula for consistentcy with brms (#264)
+* Improve error messages when attempting to construct bmmformulas without a left-hand-side variable
 
 ### Documentation
 * Add documentation to the [continuous reproduction task](https://venpopov.github.io/bmm/articles/bmm_vwm_crt.html) article for pre-processing half-circular stimulus spaces when using `bmmodels` of the `circular` model class (#229, #233).

--- a/R/bmmformula.R
+++ b/R/bmmformula.R
@@ -84,6 +84,8 @@ bmmformula <- function(...) {
     if (is_formula(out[[i]])) lhs_vars(out[[i]]) else names(out)[i]
   })
 
+  stopif(any(sapply(par_names, length) == 0), "Formulas must have a left-hand-side variable")
+
   duplicates <- duplicated(par_names)
   stopif(any(duplicates), "Duplicate formula for parameter(s) {par_names[duplicates]}")
   new_bmmformula(setNames(out, par_names))
@@ -116,8 +118,11 @@ new_bmmformula <- function(x = nlist()) {
   stopif(!is_bmmformula(f1), "The first argument must be a bmmformula.")
   f2_not_a_formula <- !(is_formula(f2) || is_bmmformula(f2)) && !is.null(f2)
   stopif(f2_not_a_formula, "The second argument must be a formula or a bmmformula.")
+  stopif(length(f2) != 0 && length(lhs_vars(f2)) == 0, "Formulas must have a left-hand-side variable") 
 
-  if (is_formula(f2)) f2 <- setNames(list(f2), lhs_vars(f2))
+  if (is_formula(f2) && length(f2) > 0) {
+    f2 <- setNames(list(f2), lhs_vars(f2))
+  }
 
   duplicates <- intersect(names(f1), names(f2))
   if (length(duplicates) > 0) {
@@ -126,6 +131,8 @@ new_bmmformula <- function(x = nlist()) {
   f1[names(f2)] <- f2
   f1
 }
+
+
 
 #' Generic S3 method for checking if the formula is valid for the specified model
 #' @param model a model list object returned from check_model()

--- a/tests/testthat/test-helpers-formula.R
+++ b/tests/testthat/test-helpers-formula.R
@@ -33,6 +33,7 @@ test_that("+.bmmformula method works", {
   # adding a null formula to a bmmformula returns the same bmmformula (#264)
   base_f <- bmf(y ~ 1)
   expect_equal(base_f, base_f + formula(NULL))
+  expect_equal(base_f, bmf(base_f[[1]], as.formula(NULL)))
 
   # the second formula must have a lhs variable
   expect_error(base_f + bmf(~ 1), "Formulas must have a left-hand-side variable")

--- a/tests/testthat/test-helpers-formula.R
+++ b/tests/testthat/test-helpers-formula.R
@@ -29,6 +29,10 @@ test_that("+.bmmformula method works", {
 
   expect_error(f6 + f1, "The first argument must be a bmmformula.")
   expect_error(f1 + 1, "The second argument must be a formula or a bmmformula.")
+
+  # adding a null formula to a bmmformula returns the same bmmformula (#264)
+  base_f <- bmf(y ~ 1)
+  expect_equal(base_f, base_f + formula(NULL))
 })
 
 describe("subsetting a bmmformula with [", {

--- a/tests/testthat/test-helpers-formula.R
+++ b/tests/testthat/test-helpers-formula.R
@@ -33,6 +33,10 @@ test_that("+.bmmformula method works", {
   # adding a null formula to a bmmformula returns the same bmmformula (#264)
   base_f <- bmf(y ~ 1)
   expect_equal(base_f, base_f + formula(NULL))
+
+  # the second formula must have a lhs variable
+  expect_error(base_f + bmf(~ 1), "Formulas must have a left-hand-side variable")
+  expect_error(base_f + formula(~ 1), "Formulas must have a left-hand-side variable")
 })
 
 describe("subsetting a bmmformula with [", {


### PR DESCRIPTION
#### Summary

closes #264 and updates NEWS. Also add a meaningful error message that bmf( ~ something) is not allowed - formulas must have a left-hand-side variable. Previously we had a cryptic error 

#### Tests

[x] Confirm that all tests passed
[x] Confirm that devtools::check() produces no errors

#### Release notes
