### PR TITLE
Fix #278: Add comma between duplicate parameters in error message

### DIFF
--- a/R/bmmformula.R
+++ b/R/bmmformula.R
@@ -85,7 +85,8 @@ bmmformula <- function(...) {
   })
 
   stopif(any(vapply(par_names, length, integer(1)) == 0), "Formulas must have a left-hand-side variable")
-  stopif(any(duplicated(par_names)), "Duplicate formula for parameter(s) {par_names[duplicates]}")
+  duplicates <- par_names[duplicated(par_names)]
+  stopif(length(duplicates) > 0, "Duplicate formula for parameter(s) {collapse_comma(duplicates)}")
   new_bmmformula(setNames(out, par_names))
 }
 

--- a/R/bmmformula.R
+++ b/R/bmmformula.R
@@ -85,7 +85,7 @@ bmmformula <- function(...) {
   })
 
   stopif(any(vapply(par_names, length, integer(1)) == 0), "Formulas must have a left-hand-side variable")
-  duplicates <- par_names[duplicated(par_names)]
+  duplicates <- unique(par_names[duplicated(par_names)])
   stopif(length(duplicates) > 0, "Duplicate formula for parameter(s) {collapse_comma(duplicates)}")
   new_bmmformula(setNames(out, par_names))
 }

--- a/tests/testthat/test-helpers-formula.R
+++ b/tests/testthat/test-helpers-formula.R
@@ -40,6 +40,15 @@ test_that("+.bmmformula method works", {
   expect_error(base_f + formula(~ 1), "Formulas must have a left-hand-side variable")
 })
 
+test_that("bmmformula gives proper error for duplicate parameters", {
+  # Test duplicate formula error message includes proper comma separation
+  expect_error(bmf(m1 ~ 1, m1 ~ 2), "Duplicate formula for parameter\\(s\\) 'm1'")
+  expect_error(
+    bmf(m1 ~ 1, m2 ~ 1, m1 ~ 2, m2 ~ 2),
+    "Duplicate formula for parameter\\(s\\) 'm1', 'm2'"
+  )
+})
+
 describe("subsetting a bmmformula with [", {
   f <- bmf(y ~ exp(a) + b, a ~ 1 + (1 | id), b ~ 1, c = 3)
 


### PR DESCRIPTION
## Summary
Fixes #278 

## Changes
- Fixed duplicate formula error message to properly separate parameter names with commas
- Added `duplicates` variable to identify duplicated parameters before using in error message
- Used `collapse_comma()` for consistent formatting (matching pattern in line 127)
- Added test cases for both single and multiple duplicate parameters

## Before
```
Error: Duplicate formula for parameter(s) m1Duplicate formula for parameter(s) m2
```

## After
```
Error: Duplicate formula for parameter(s) 'm1', 'm2'
```

## Testing
- Added new test `test_that("bmmformula gives proper error for duplicate parameters")`
- All existing tests pass
- R CMD CHECK passes with 0 errors, 0 warnings