### PR TITLE
Enhance AGENTS.md with pure function guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,16 @@ These functions:
 - **Functional patterns**: Use functional programming where possible
 - **Explicit namespacing**: Always use `package::function()` (e.g., `brms::lf()`, `glue::glue()`)
 - Only use functions from packages in `DESCRIPTION` "Imports"
+- **Pure functions**: Always write functions that preserve the global state
+- NEVER use a `seed` argument and `set.seed` inside of functions
+
+```r
+# Bad - never do this
+myfun <- function(n, seed) {
+   set.seed(seed)
+   rnorm(n)
+}
+```
 
 ### String Formatting
 Use `glue::glue()` instead of `sprintf()`:


### PR DESCRIPTION
Add guidelines for pure functions and seeding in AGENTS.md

I saw AI generated code in R often follows this anti-pattern of 

```r
myfun <- function(n, seed) {
   set.seed(seed)
   rnorm(n)
}
```

This is bad because it alters the global seed an can introduce problems in user scripts and reproducibility. Users should be entirely responsible for seed manipulations. 

An alternative if we must have seed arguments somewhere is to use withr::with_local_seed, which does not alter the global state. But I'd rather we just forbid this

#### Summary

#### Tests

[] Confirm that all tests passed
[] Confirm that devtools::check() produces no errors

#### Release notes
