### PR TITLE
Fix swald_lccdf returning -inf instead of 0 for t <= ndt

### DIFF
--- a/inst/stan_chunks/cswald_helper_functions.stan
+++ b/inst/stan_chunks/cswald_helper_functions.stan
@@ -26,7 +26,7 @@ real swald_lpdf(real rt, real drift, real bound, real ndt, real sigma) {
 real swald_lccdf(real rt, real drift, real bound, real ndt, real sigma) {
   // compute shifted response time
   real t_shifted = rt - ndt;
-  if (t_shifted <= 0) return negative_infinity();
+  if (t_shifted <= 0) return 0;  // process hasn't started, survival = 1
 
   // pre-compute common terms
   real sqrt_t = sqrt(t_shifted);


### PR DESCRIPTION
While working on some tutorial scripts for the evidence accumulation models I stumbled across a bug in the `swald_lccdf` function. In swald_lccdf (cswald_helper_functions.stan:29)the log-survival function returned negative_infinity() when rt - ndt <= 0. The correct return value is 0 (log of survival probability 1), since the decision process hasn't started yet.

The density function `swald_lpdf` correctly returns -infinity() for this case (density = 0), but the survivor function must return 0 (survival = 1).
